### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -1,0 +1,17 @@
+name: C++ CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: make
+      run: make

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/src/class/Server.cpp
+++ b/src/class/Server.cpp
@@ -240,7 +240,8 @@ sockaddr_in Server::_init_address(port_t port)
 		.sin_port = htons(port),
 		.sin_addr = (struct in_addr) {
 			.s_addr = INADDR_ANY
-		}
+		},
+		.sin_zero = {},
 	};
 }
 


### PR DESCRIPTION
This GitHub Action `make` the project to avoid compilations errors on master branch.

It compile on the latest Ubuntu LTS and uses a more recent C++ compiler than one available at school.

Modern compilers implement stricter standards compliance checks and identify more problematic patterns and undefined behavior