### PR TITLE
Update command structure to include min and max argument sizes

### DIFF
--- a/include/class/Command.hpp
+++ b/include/class/Command.hpp
@@ -14,7 +14,8 @@ private:
 	typedef void	(*_command_handler_t)(const args_t &, Client &);
 	typedef struct {
 		_command_handler_t	handler;
-		size_t				args_size;
+		size_t				min_args;
+		size_t				max_args;
 		bool				need_registration;
 	}	_command_t;
 	typedef std::map<std::string, _command_t>	_commands_t;

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -3,9 +3,9 @@
 
 void Command::init()
 {
-	_commands["nick"] = (_command_t) {&_nick, 1, false};
-	_commands["pass"] = (_command_t) {&_pass, 1, false};
-	_commands["user"] = (_command_t) {&_user, 4, false};
+	_commands["nick"] = (_command_t) {&_nick, 1, 1, false};
+	_commands["pass"] = (_command_t) {&_pass, 1, 1, false};
+	_commands["user"] = (_command_t) {&_user, 4, 4, false};
 }
 
 void Command::execute(const args_t &args, Client &client)
@@ -20,7 +20,8 @@ void Command::execute(const args_t &args, Client &client)
 
 	_command_t command = command_it->second;
 
-	if (args.size() - 1 != command.args_size)
+	size_t args_size(args.size() - 1);
+	if (args_size > command.max_args || args_size < command.min_args)
 		return client.reply(ERR_NEEDMOREPARAMS, args[0], "Syntax error");
 
 	if (command.need_registration && !client.is_registered())

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -20,7 +20,7 @@ void Command::execute(const args_t &args, Client &client)
 
 	_command_t command = command_it->second;
 
-	size_t args_size(args.size() - 1);
+	size_t args_size = args.size() - 1;
 	if (args_size > command.max_args || args_size < command.min_args)
 		return client.reply(ERR_NEEDMOREPARAMS, args[0], "Syntax error");
 


### PR DESCRIPTION
This pull request introduces changes to the `Command` class to improve the handling of command arguments by specifying both minimum and maximum arguments required for each command. The most important changes include updating the `_command_t` struct and modifying the initialization and execution logic for commands.

Enhancements to command argument handling:

* [`include/class/Command.hpp`](diffhunk://#diff-95e88a26aedcfb6452dc1f3b3f0824452d85b343de512ea31cc00150c00a4ca4L17-R18): Updated the `_command_t` struct to include `min_args` and `max_args` instead of a single `args_size` parameter.
* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L6-R8): Modified the initialization of commands in the `Command::init` method to specify both `min_args` and `max_args` for each command.
* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L23-R24): Updated the `Command::execute` method to check if the number of arguments falls within the specified `min_args` and `max_args` range.