### PR TITLE
Fix channel verbose

### DIFF
--- a/include/class/Channel.hpp
+++ b/include/class/Channel.hpp
@@ -36,13 +36,13 @@ private:
 	Client				&_creator;
 
 	std::string		_passkey;
-	
+
 	bool			_limit_members;
 	size_t			_max_members;
 	bool			_is_invite_only;
 	std::vector<std::string> _banned_user_masks; // eg: nick!*@* , *!*@192.168.1.* ...
 
-	const bool		_verbose;
+	const bool	_verbose;
 };
 
 #endif // CHANNEL_HPP

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -72,9 +72,9 @@ void Command::_join(const args_t &args, Client &client)
 	std::vector<Channel *> channels_to_be_joined;
 	std::vector<std::string> passkeys;
 	Server &server = client.get_server();
-	
+
 	std::vector<std::string> channels_name = ft_split(args[1], ',');
-	std::vector<std::string> input_passkeys = args_size == 3 ? 
+	std::vector<std::string> input_passkeys = args_size == 3 ?
 		ft_split(args[2], ',') : std::vector<std::string>();
 
 	for (size_t i = 0; i < channels_name.size(); i++)
@@ -86,7 +86,7 @@ void Command::_join(const args_t &args, Client &client)
 			Channel *new_channel = server.find_channel(channel_name);
 			if (!new_channel) {
 				// the channel does not exists and needs to be created
-				new_channel = new Channel(client, channel_name);
+				new_channel = new Channel(client, channel_name, client.get_server().is_verbose());
 				server.add_channel(*new_channel);
 			}
 
@@ -94,11 +94,11 @@ void Command::_join(const args_t &args, Client &client)
 
 			if (args_size == 3)
 				passkeys.push_back(input_passkeys.size() > i ? input_passkeys[i] : "");
-		
+
 		} else {
 			client.reply(
-				ERR_NOSUCHCHANNEL, 
-				channels_name[i], 
+				ERR_NOSUCHCHANNEL,
+				channels_name[i],
 				"No such channel"
 			);
 		}


### PR DESCRIPTION
This pull request includes a change to the `void Command::_join(const args_t &args, Client &client)` function in the `src/class/Command.cpp` file. The change involves modifying the `Channel` constructor to include an additional parameter, which is the result of calling `client.get_server().is_verbose()`.

* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L89-R89): Modified the `Channel` constructor call in the `_join` method to include a verbosity flag from the server.