### PR TITLE
Implement QUIT command handling (+fix some errors)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ DEP = $(OBJ:.o=.d)
 $(NAME): $(OBJ)
 	$(CXX) $(CXXFLAGS) -o $@ $^
 
-$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp
+$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp Makefile
 	@$(MKDIR) $(@D)
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 

--- a/include/class/Channel.hpp
+++ b/include/class/Channel.hpp
@@ -26,6 +26,7 @@ public:
 	void	set_is_invite_only(bool invite_only);
 
 	void	add_client(Client &client);
+	void	remove_client(int client_fd);
 
 	static const size_t max_channel_name_size = 50;
 
@@ -34,7 +35,6 @@ public:
 private:
 	const std::string	_name;
 	clients_t			_members;
-	Client				&_creator;
 
 	std::string		_passkey;
 

--- a/include/class/Client.hpp
+++ b/include/class/Client.hpp
@@ -11,7 +11,7 @@ class Server;
 class Client
 {
 public:
-	Client(const int fd, const std::string &ip, Server &server);
+	Client(const int fd, const std::string ip, Server &server);
 	~Client();
 
 	void	handle_messages(std::string messages);
@@ -31,6 +31,7 @@ public:
 	const int			&get_fd( void );
 	bool				is_invited_to(Channel &channel);
 	std::string			get_mask( void ) const;
+	channels_t			&get_active_channels( void );
 	size_t				get_channels_count( void ) const;
 
 	Server	&get_server() const;
@@ -44,7 +45,7 @@ public:
 
 private:
 	const int			_fd;
-	const std::string	&_ip;
+	const std::string	_ip;
 	Server				&_server;
 
 	bool		_disconnect_request;

--- a/include/class/Command.hpp
+++ b/include/class/Command.hpp
@@ -28,6 +28,7 @@ private:
 	static void	_user(const args_t &args, Client &client);
 	static void	_join(const args_t &args, Client &client);
 	static void	_ping(const args_t &args, Client &client);
+	static void	_quit(const args_t &args, Client &client);
 };
 
 #endif // COMMAND_HPP

--- a/src/class/Channel.cpp
+++ b/src/class/Channel.cpp
@@ -3,7 +3,6 @@
 
 Channel::Channel(Client &creator, std::string &name, const bool verbose):
 	_name(name),
-	_creator(creator),
 	_passkey(),
 	_limit_members(false),
 	_is_invite_only(false),
@@ -61,6 +60,11 @@ void Channel::set_is_invite_only(bool invite_only)
 void Channel::add_client(Client &client)
 {
 	_members[client.get_fd()] = &client;
+}
+
+void Channel::remove_client(int client_fd)
+{
+	_members.erase(client_fd);
 }
 
 bool Channel::is_full(void)

--- a/src/class/Client.cpp
+++ b/src/class/Client.cpp
@@ -345,6 +345,11 @@ std::string	Client::get_mask(void) const
 	return std::string(_nickname + "!" + _username + "@" + _ip);
 }
 
+channels_t &Client::get_active_channels( void )
+{
+	return _active_channels;
+}
+
 size_t Client::get_channels_count(void) const
 {
 	return _active_channels.size();

--- a/src/class/Client.cpp
+++ b/src/class/Client.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <algorithm>
 
-Client::Client(const int fd, const std::string &ip, Server &server):
+Client::Client(const int fd, const std::string ip, Server &server):
 	_fd(fd),
 	_ip(ip),
 	_server(server),

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -8,6 +8,7 @@ void Command::init()
 	_commands["ping"] = (_command_t) {&_ping, 1, 1, true};
 	_commands["join"] = (_command_t) {&_join, 1, 2, true};
 	_commands["motd"] = (_command_t) {&_motd, 0, 1, true};
+	_commands["quit"] = (_command_t) {&_quit, 0, 1, true};
 	_commands["nick"] = (_command_t) {&_nick, 1, 1, false};
 	_commands["pass"] = (_command_t) {&_pass, 1, 1, false};
 	_commands["user"] = (_command_t) {&_user, 4, 4, false};
@@ -131,4 +132,22 @@ void Command::_ping(const args_t &args, Client &client)
 	client.send(client.create_cmd_reply(
 		client.get_server().get_name(), "PONG", response_args
 	));
+}
+
+void Command::_quit(const args_t &args, Client &client)
+{
+	std::string quit_message = "Client Quit";
+	if (args.size() > 1)
+		quit_message = args[1];
+
+	args_t response_args;
+	response_args.push_back(quit_message);
+	
+	channels_t client_channels = client.get_active_channels();
+	for (channels_t::iterator channel = client_channels.begin(); channel != client_channels.end(); channel++) {
+		channel->second->remove_client(client.get_fd());
+		channel->second->send_broadcast(client.create_cmd_reply(
+			client.get_mask(), "QUIT", response_args
+		));
+	}
 }


### PR DESCRIPTION
This pull request includes several changes to the `Channel`, `Client`, and `Command` classes, as well as updates to the `Makefile`. The primary focus is on adding functionality for client removal, modifying constructors, and extending command capabilities.

### Additions and Modifications to Class Functionality:

* [`include/class/Channel.hpp`](diffhunk://#diff-e948e43ff1c57d90d61f9c64c956866cbea25bf4d9f2b56a8bf99141078f5186R29): Added `remove_client` method to the `Channel` class to allow for client removal.
* [`include/class/Client.hpp`](diffhunk://#diff-8fa98d2922f00aad59a61ca4e9e3a7725062a736eb543f642eba8ca933183921R34): Added `get_active_channels` method to the `Client` class to retrieve active channels.
* [`include/class/Command.hpp`](diffhunk://#diff-95e88a26aedcfb6452dc1f3b3f0824452d85b343de512ea31cc00150c00a4ca4R31): Added `_quit` command to the `Command` class to handle client quit operations.

### Constructor and Member Variable Changes:

* [`include/class/Client.hpp`](diffhunk://#diff-8fa98d2922f00aad59a61ca4e9e3a7725062a736eb543f642eba8ca933183921L14-R14): Changed the `Client` constructor to accept `std::string` instead of `const std::string&` for the IP address parameter.
* [`include/class/Client.hpp`](diffhunk://#diff-8fa98d2922f00aad59a61ca4e9e3a7725062a736eb543f642eba8ca933183921L47-R48): Modified the `_ip` member variable to be a `std::string` instead of a `const std::string&`.
* [`src/class/Channel.cpp`](diffhunk://#diff-9561c03c8d58c688baa36075b0c781a8bb977e74f6e2dd6a6322fe072f9b1bd3L6): Removed the `_creator` member variable from the `Channel` class.

### Command Handling Enhancements:

* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1R136-R153): Implemented the `_quit` command to handle client quit operations, including broadcasting quit messages to channels and removing clients from channels.
* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1R11): Added the `_quit` command to the command initialization in `Command::init()`.

### Build System Update:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L33-R33): Updated the build rule for object files to include the `Makefile` as a dependency, ensuring that changes to the `Makefile` trigger a rebuild of the object files.