### PR TITLE
Refactor `create_cmd_reply`

### DIFF
--- a/include/class/Client.hpp
+++ b/include/class/Client.hpp
@@ -19,13 +19,12 @@ public:
 	ssize_t	send(const std::string &message) const;
 	void	send_error(const std::string &message);
 
-	void	invite_to_channel(Client &target, Channel &channel);
 	bool	join_channel(Channel &channel, std::string passkey);
-	void	kick_channel(Channel &chennel, std::string kicked_client, args_t args);
+	void	kick_channel(Channel &channel, const std::string &kicked_client, const std::string &reason);
 	void	notify_quit();
 
 	void	reply(reply_code code, const std::string &arg = "", const std::string &message = "") const;
-	void	cmd_reply(const std::string &prefix, const std::string &cmd, args_t &args) const;
+	void	cmd_reply(const std::string &prefix, const std::string &cmd, const std::string &arg = "", const std::string &message = "") const;
 
 	const std::string	create_motd_reply() const;
 
@@ -52,7 +51,7 @@ public:
 
 	bool	operator==(const Client &other) const;
 
-	static const std::string	create_cmd_reply(const std::string &prefix, const std::string &cmd, args_t &args);
+	static const std::string	create_cmd_reply(const std::string &prefix, const std::string &cmd, const std::string &arg = "", const std::string &message = "");
 
 private:
 	const int			_fd;

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -65,11 +65,7 @@ void Command::_invite(const args_t &args, Client &client)
 		channel->invite_client(*target);
 	}
 
-	args_t response_args;
-	response_args.push_back(args[1]);
-	response_args.push_back(args[2]);
-
-	target->cmd_reply(client.get_mask(), "INVITE", response_args);
+	target->cmd_reply(client.get_mask(), "INVITE", args[1], args[2]);
 	client.reply(RPL_INVITING, args[1] + ' ' + args[2]);
 }
 
@@ -150,15 +146,12 @@ void Command::_join(const args_t &args, Client &client)
 
 		std::string passkey = args_size == 3 && passkeys.size() > i ? passkeys[i] : "";
 
-		args_t response_args;
-		response_args.push_back(channel->get_name());
-
 		if (!client.join_channel(*channel, passkey))
 			server.delete_channel(channel->get_name());
 		else
 		{
 			channel->send_broadcast(Client::create_cmd_reply(
-			client_mask, "JOIN", response_args
+			client_mask, "JOIN", "", channel->get_name()
 			));
 		}
 	}
@@ -166,11 +159,7 @@ void Command::_join(const args_t &args, Client &client)
 
 void Command::_ping(const args_t &args, Client &client)
 {
-	args_t response_args;
-	response_args.push_back(client.get_server().get_name());
-	response_args.push_back(args[1]);
-
-	client.cmd_reply(client.get_server().get_name(), "PONG", response_args);
+	client.cmd_reply(client.get_server().get_name(), "PONG", client.get_server().get_name(), args[1]);
 }
 
 void Command::_quit(const args_t &args, Client &client)
@@ -196,10 +185,6 @@ void Command::_privmsg(const args_t &args, Client &client)
 	for (std::vector<std::string>::iterator it = recipients.begin(); it != recipients.end(); it++) {
 		std::string recipient = *it;
 
-		args_t response_args;
-		response_args.push_back(recipient);
-		response_args.push_back(message);
-
 		if (recipient[0] == '#' || recipient[0] == '&') {
 			Channel *channel = client.get_server().find_channel(recipient);
 
@@ -210,7 +195,7 @@ void Command::_privmsg(const args_t &args, Client &client)
 				client.reply(ERR_NOTONCHANNEL, recipient, "You are not on that channel");
 
 			else {
-				std::string message = Client::create_cmd_reply(client.get_mask(), "PRIVMSG", response_args);
+				std::string message = Client::create_cmd_reply(client.get_mask(), "PRIVMSG", recipient, message);
 				channel->send_broadcast(message, client.get_fd());
 			}
 		}
@@ -221,7 +206,7 @@ void Command::_privmsg(const args_t &args, Client &client)
 			if (!target)
 				return client.reply(ERR_NOSUCHNICK, recipient, "No such nick or channel name");
 
-			target->cmd_reply(client.get_mask(), "PRIVMSG", response_args);
+			target->cmd_reply(client.get_mask(), "PRIVMSG", recipient, message);
 		}
 	}
 }
@@ -252,14 +237,7 @@ void Command::_kick(const args_t &args, Client &client)
 	}
 
 	for (size_t i = 0; i < channels_to_kick_from.size(); i++)
-	{
-		args_t args;
-		args.push_back(channels_to_kick_from[i]->get_name());
-		args.push_back(kicked_client);
-		args.push_back(reason);
-
-		client.kick_channel(*channels_to_kick_from[i], kicked_client, args);
-	}
+		client.kick_channel(*channels_to_kick_from[i], kicked_client, reason);
 }
 
 void Command::_mode(const args_t &args, Client &client)
@@ -273,7 +251,7 @@ void Command::_mode(const args_t &args, Client &client)
 
 	if (args.size() == 2) {
 		client.reply(RPL_CHANNELMODEIS, channel_name, channel->get_modes(channel->is_client_member(client)));
-		client.reply(RPL_CREATIONTIME, channel_name, channel->get_creation_timestamp());		
+		client.reply(RPL_CREATIONTIME, channel_name, channel->get_creation_timestamp());
 		return ;
 	}
 
@@ -357,17 +335,13 @@ void Command::_mode(const args_t &args, Client &client)
 	}
 
 	if (!applied_flags.empty())
-	{	
-		args_t response_args;
-		response_args.push_back(channel_name);
-			
+	{
 		Channel::modes_t modes = { flags: applied_flags, values: modes_values };
 
-		response_args.push_back(Channel::stringify_modes(&modes));
 		channel->add_modes(&modes);
 
 		channel->send_broadcast(Client::create_cmd_reply(
-			client.get_mask(), "MODE", response_args
+			client.get_mask(), "MODE", channel_name + ' ' + Channel::stringify_modes(&modes)
 		));
 	}
 }


### PR DESCRIPTION
This pull request includes several changes to the `Client` and `Command` classes to simplify the method signatures and improve code readability. The most important changes include modifying the `cmd_reply` and `create_cmd_reply` methods to use separate `arg` and `message` parameters instead of a single `args_t` parameter, and updating related method calls accordingly.

Improvements to `Client` class:

* [`include/class/Client.hpp`](diffhunk://#diff-8fa98d2922f00aad59a61ca4e9e3a7725062a736eb543f642eba8ca933183921L22-R27): Modified the `cmd_reply` and `create_cmd_reply` methods to use separate `arg` and `message` parameters. [[1]](diffhunk://#diff-8fa98d2922f00aad59a61ca4e9e3a7725062a736eb543f642eba8ca933183921L22-R27) [[2]](diffhunk://#diff-8fa98d2922f00aad59a61ca4e9e3a7725062a736eb543f642eba8ca933183921L55-R54)
* [`src/class/Client.cpp`](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L70-R72): Updated the `cmd_reply`, `create_cmd_reply`, `kick_channel`, and `notify_quit` methods to use the new method signatures. [[1]](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L70-R72) [[2]](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L197-R206) [[3]](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L266-R260) [[4]](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L405-R394) [[5]](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L421-R410) [[6]](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L444-R433)

Improvements to `Command` class:

* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L68-R68): Updated the `_invite`, `_join`, `_ping`, `_quit`, `_privmsg`, `_kick`, and `_mode` methods to use the new `cmd_reply` and `create_cmd_reply` method signatures. [[1]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L68-R68) [[2]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L153-R162) [[3]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L199-L202) [[4]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L213-R198) [[5]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L224-R209) [[6]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L255-R240) [[7]](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L361-R344)