### PR TITLE
Fix MODE compilation errors

### DIFF
--- a/src/class/Channel.cpp
+++ b/src/class/Channel.cpp
@@ -172,7 +172,7 @@ std::string Channel::stringify_modes(Channel::modes_t *modes, bool add_modes_val
 {
 	if (modes->flags.empty())
 		return "+";
-    
+
 	std::string str_flags;
 	std::string str_values;
 	char current_sign = 0;
@@ -205,9 +205,9 @@ void Channel::add_modes(modes_t *modes)
 			_modes.flags.push_back(modes->flags[i]);
 		} else {
 			_modes.flags.erase(std::find(
-				_modes.flags.begin(), 
-				_modes.flags.end(), 
-				"-" + mode
+				_modes.flags.begin(),
+				_modes.flags.end(),
+				std::string("-") + mode
 			));
 		}
 	}

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -338,7 +338,10 @@ void Command::_mode(const args_t &args, Client &client)
 
 	if (!applied_flags.empty())
 	{
-		Channel::modes_t modes = { flags: applied_flags, values: modes_values };
+		Channel::modes_t modes = {
+			.flags = applied_flags,
+			.values = modes_values
+		};
 
 		channel->add_modes(&modes);
 
@@ -358,25 +361,25 @@ void Command::_topic(const args_t &args, Client &client)
 
 	if (!channel->is_client_member(client))
 		return client.reply(ERR_NOTONCHANNEL, channel_name, "You are not on that channel");
-	
+
 	std::string channel_topic = channel->get_topic();
 
 	if (args.size() == 2)
 	{
 		if (channel_topic.empty())
 			return client.reply(RPL_NOTOPIC, channel_name, "No topic is set");
-		
+
 		std::string reply = client.create_reply(
 			RPL_TOPIC,
-			channel_name, 
+			channel_name,
 			channel_topic
 		);
 		reply += client.create_reply(
-			RPL_TOPICWHOTIME, 
-			channel_name + " " + channel->get_topic_last_edited_by(), 
+			RPL_TOPICWHOTIME,
+			channel_name + " " + channel->get_topic_last_edited_by(),
 			channel->get_topic_last_edited_at()
 		);
-		
+
 		client.send(reply);
 		return ;
 	}
@@ -406,7 +409,7 @@ void Command::_who(const args_t &args, Client &client)
 		context = mask;
 		Channel *channel = server->find_channel(mask);
 		if (channel)
-			clients = channel->get_members();	
+			clients = channel->get_members();
 	} else if (!operator_flag) {
 		clients = server->get_clients(mask);
 	}


### PR DESCRIPTION
This pull request includes changes to improve the handling of mode flags in the `Channel` and `Command` classes. The most important changes include modifying the way strings are concatenated and the initialization of the `modes_t` structure.

Improvements to mode flag handling:

* [`src/class/Channel.cpp`](diffhunk://#diff-9561c03c8d58c688baa36075b0c781a8bb977e74f6e2dd6a6322fe072f9b1bd3L210-R210): Changed the concatenation of strings in the `Channel::add_modes` method to use `std::string` for better clarity and safety.
* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L341-R344): Modified the initialization of the `Channel::modes_t` structure in the `Command::_mode` method to use designated initializers for better readability and maintainability.