### PR TITLE
Refactor WHO

### DIFF
--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -425,8 +425,6 @@ void Command::_who(const args_t &args, Client &client)
 		);
 	}
 
-	if (!reply.empty())
-		client.send(reply);
-
-	client.reply(RPL_ENDOFWHO, context, "End of WHO list");
+	reply += client.create_reply(RPL_ENDOFWHO, context, "End of WHO list");
+	client.send(reply);
 }


### PR DESCRIPTION
This pull request includes a small change to the `Command::_who` method in the `src/class/Command.cpp` file. The change consolidates the creation of the reply message by appending the "End of WHO list" message to the existing reply string before sending it, instead of sending it separately.

Changes to `Command::_who` method:

* Consolidated the creation of the reply message by appending the "End of WHO list" message to the existing reply string before sending it.