### PR TITLE
Fix variable naming in PRIVMSG

### DIFF
--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -197,8 +197,8 @@ void Command::_privmsg(const args_t &args, Client &client)
 				client.reply(ERR_NOTONCHANNEL, recipient, "You are not on that channel");
 
 			else {
-				std::string message = Client::create_cmd_reply(client.get_mask(), "PRIVMSG", recipient, message);
-				channel->send_broadcast(message, client.get_fd());
+				std::string reply = Client::create_cmd_reply(client.get_mask(), "PRIVMSG", recipient, message);
+				channel->send_broadcast(reply, client.get_fd());
 			}
 		}
 


### PR DESCRIPTION
This pull request includes a minor change to the `Command::_privmsg` method in the `src/class/Command.cpp` file. The change involves renaming a variable to improve code readability.

* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1L200-R201): Renamed the variable `message` to `reply` to clarify its purpose in the `Command::_privmsg` method.