### PR TITLE
ADD: PART command, client can leave a channel(or more)

### DIFF
--- a/include/class/Client.hpp
+++ b/include/class/Client.hpp
@@ -22,6 +22,7 @@ public:
 
 	bool	join_channel(Channel &channel, std::string passkey);
 	void	kick_channel(Channel &channel, const std::string &kicked_client, std::string &reason);
+	void	part_channel(Channel &channel, std::string &reason);
 	void	notify_quit();
 
 	void	reply(reply_code code, const std::string &arg = "", const std::string &message = "") const;
@@ -29,20 +30,21 @@ public:
 
 	const std::string	create_motd_reply() const;
 
-	const bool			&has_disconnect_request() const;
-	const bool			&is_registered() const;
-	bool				is_channel_operator(std::string channel_name) const;
-	const std::string	&get_nickname(bool allow_empty = true) const;
-	const int			&get_fd( void );
-	std::string			get_mask( void ) const;
-	channels_t			&get_active_channels( void );
-	size_t				get_channels_count( void ) const;
-	std::string			get_realname( void ) const;
-	std::string			generate_who_reply(const std::string &context) const;
+	const bool					&has_disconnect_request() const;
+	const bool					&is_registered() const;
+	bool						is_channel_operator(std::string channel_name) const;
+	std::vector<std::string>	&get_channels_operator( void );
+	const std::string			&get_nickname(bool allow_empty = true) const;
+	const int					&get_fd( void );
+	std::string					get_mask( void ) const;
+	channels_t					&get_active_channels( void );
+	size_t						get_channels_count( void ) const;
+	std::string					get_realname( void ) const;
+	std::string					generate_who_reply(const std::string &context) const;
 
 	Channel				*get_channel(const std::string &name);
 
-	Server	&get_server() const;
+	Server	&get_server() const;	
 
 	void	set_nickname(const std::string &nickname);
 	void	set_username(const std::string &username);

--- a/include/class/Client.hpp
+++ b/include/class/Client.hpp
@@ -44,7 +44,7 @@ public:
 
 	Channel				*get_channel(const std::string &name);
 
-	Server	&get_server() const;	
+	Server	&get_server() const;
 
 	void	set_nickname(const std::string &nickname);
 	void	set_username(const std::string &username);

--- a/include/class/Command.hpp
+++ b/include/class/Command.hpp
@@ -37,6 +37,7 @@ private:
 	static void _who(const args_t &args, Client &client);
 	static void _hk(const args_t &args, Client &client);
 	static void _names(const args_t &args, Client &client);
+	static void _part(const args_t &args, Client &client);
 };
 
 #endif // COMMAND_HPP

--- a/src/class/Client.cpp
+++ b/src/class/Client.cpp
@@ -245,8 +245,7 @@ void Client::_handle_message(std::string message)
 	if (message[message.size() - 1] == '\r')
 		message.erase(message.size() - 1);
 
-	args_t args;
-	size_t pos;
+	args_t args;remove_channel_operator
 	while ((pos = message.find(' ')) != std::string::npos && message.find(':') != 0)
 	{
 		if (pos > 0)
@@ -472,8 +471,7 @@ void	Client::part_channel(Channel &channel, std::string &reason)
 		));
 		channel.remove_client(*this);
 		get_active_channels().erase(channel.get_name());
-		std::vector<std::string> chan_op = get_channels_operator();
-		chan_op.erase(std::remove(chan_op.begin(), chan_op.end(), channel.get_name()), chan_op.end());
+		remove_channel_operator(channel.get_name());
 	}
 	if (channel.get_members().empty())
 		server.delete_channel(channel.get_name());

--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -25,6 +25,7 @@ void Command::init()
 	_commands["who"] = (_command_t) {&_who, 0, 2, true};
 	_commands["hk"] = (_command_t) {&_hk, 0, 1, false};
 	_commands["names"] = (_command_t) {&_names, 0, 1, true};
+	_commands["part"] = (_command_t) {&_part, 1, 2, true};
 
 	std::srand(std::time(NULL));
 }
@@ -505,4 +506,31 @@ void Command::_names(const args_t &args, Client &client)
 	}
 
 	client.send(reply);
+}
+
+void Command::_part(const args_t &args, Client &client)
+{
+	Server						&server = client.get_server();
+	std::vector<Channel *>		channels_to_quit;
+	std::vector<std::string>	channels_name = ft_split(args[1], ',');
+	std::string 				reason = args.size() == 3 ? args[2] : "Leaving";
+
+	for (size_t i = 0; i < channels_name.size(); i++)
+	{
+		std::string channel_name = channels_name[i];
+		Channel *new_channel = server.get_channel(channel_name);
+		if (!new_channel)
+		{
+			client.reply(
+				ERR_NOSUCHCHANNEL,
+				channels_name[i],
+				"No such channel"
+			);
+		}
+		else
+			channels_to_quit.push_back(new_channel);
+	}
+
+	for (size_t j = 0; j < channels_to_quit.size(); j++)
+		client.part_channel(*channels_to_quit[j], reason);
 }


### PR DESCRIPTION
### The PART command is used when a client wants to leave one or more IRC channels. Here are its key characteristics:

**Purpose**
- Allows a client to exit (part) from a specific channel or multiple channels
- Notifies other channel members that the client has left


**Syntax**

- Basic format: PART #channel[,#channel2,...] [:optional part message]
- Can leave a single channel or multiple channels in one command
- Optional part message can be included to explain why they're leaving


**Behavior**
When a client parts a channel, they:
- Are removed from the channel's user list
- Broadcast a PART message to all remaining channel members
- Can no longer send messages to that channel
- Lose their channel-specific privileges (ops, voice, etc.)




**Variations**
- Single channel part: /PART #channelname
- Multiple channel part: /PART #channel1,#channel2
- Part with message: /PART #channel :Goodbye all!


**Error Conditions**
- Cannot part a channel you're not in
- Cannot part a non-existent channel
- Requires at least one channel name parameter


**Server-Side Handling**
- Validates the client's presence in the channel
- Removes client from channel's user list
- Broadcasts PART message to channel members
- May clean up the channel if it becomes empty

The PART command is a fundamental part of channel management in IRC, allowing users to gracefully exit channels they no longer wish to participate in.