### PR TITLE
Add early return for empty command arguments in Command::execute

### DIFF
--- a/src/class/Command.cpp
+++ b/src/class/Command.cpp
@@ -30,6 +30,9 @@ void Command::init()
 
 void Command::execute(const args_t &args, Client &client, Server &server)
 {
+	if (args.empty())
+		return;
+
 	_commands_t::iterator command_it = _commands.find(to_lower(args[0]));
 
 	if (command_it == _commands.end()) {


### PR DESCRIPTION
This pull request includes a small change to the `Command::execute` method in the `src/class/Command.cpp` file. The change adds a check to return early if the `args` vector is empty, which prevents further processing when there are no arguments provided.

* [`src/class/Command.cpp`](diffhunk://#diff-99a875f4ebda4f241f0846ef7136b71a5236683f6c434eea4e59412a74a2a0a1R33-R35): Added a check to return early in the `Command::execute` method if the `args` vector is empty.