### PR TITLE
Fix Client::is_channel_operator (oops, sorry)

### DIFF
--- a/src/class/Channel.cpp
+++ b/src/class/Channel.cpp
@@ -97,11 +97,14 @@ const std::string Channel::list_members( void )
 {
 	std::string result;
 
-	bool is_chan_op;
 	for (clients_t::iterator it = this->_members.begin(); it != this->_members.end(); it++) {
-		is_chan_op = it->second->is_channel_operator(this->_name);
-		if (!result.empty()) result += " ";
-		result += std::string(is_chan_op ? "@" : "") + it->second->get_nickname();
+		Client &member = *it->second;
+		bool is_op = member.is_channel_operator(this->_name);
+
+		if (!result.empty())
+			result += " ";
+
+		result += std::string(is_op ? "@" : "") + member.get_nickname();
 	}
 
 	return result;

--- a/src/class/Client.cpp
+++ b/src/class/Client.cpp
@@ -131,8 +131,8 @@ bool Client::is_channel_operator(std::string channel_name) const
 {
 	const std::string &lower_channel_name = to_lower(channel_name);
 
-	for (channels_t::const_iterator it = _active_channels.begin(); it != _active_channels.end(); ++it)
-		if (to_lower(it->first) == lower_channel_name)
+	for (std::vector<std::string>::const_iterator it = _channel_operator.begin(); it != _channel_operator.end(); ++it)
+		if (to_lower(*it) == lower_channel_name)
 			return true;
 
 	return false;


### PR DESCRIPTION
This pull request includes changes to improve the readability and efficiency of the `Channel` and `Client` classes in the project. The key updates involve refactoring the methods to enhance clarity and performance.

Refactoring for readability and efficiency:

* [`src/class/Channel.cpp`](diffhunk://#diff-9561c03c8d58c688baa36075b0c781a8bb977e74f6e2dd6a6322fe072f9b1bd3L100-R107): Refactored the `list_members` method to use a more descriptive variable name (`member` instead of `it->second`) and improved the readability of the code by restructuring the loop and conditionals.
* [`src/class/Client.cpp`](diffhunk://#diff-7d98473a6ad047567921f5109c8e0e5e9786dcfee60fbba04989116279823e61L134-R135): Updated the `is_channel_operator` method to iterate over `_channel_operator` instead of `_active_channels`, simplifying the logic and improving performance.