### PR TITLE
Add missing MODE +o reply

### DIFF
--- a/src/class/Command/mode.cpp
+++ b/src/class/Command/mode.cpp
@@ -104,11 +104,7 @@ static void mode_handler(const args_t &args, Client &client, Server &server)
 			else
 				new_op->remove_channel_operator(channel_name);
 
-			channel->broadcast(
-				Client::create_cmd_reply(client.get_mask(), "MODE", channel_name + ' ' + (add_mode ? '+' : '-') + "o " + new_op->get_nickname())
-			);
-
-			continue;
+			modes_values[mode] = value;
 		}
 
 		std::string flag = add_mode ? "+" : "-";

--- a/src/class/Command/mode.cpp
+++ b/src/class/Command/mode.cpp
@@ -85,7 +85,8 @@ static void mode_handler(const args_t &args, Client &client, Server &server)
 		}
 
 		else if (mode == 'o') {
-			if (value.empty()) continue;
+			if (value.empty())
+				continue;
 
 			Client *new_op = server.get_client(value);
 			if (!new_op) {
@@ -102,6 +103,12 @@ static void mode_handler(const args_t &args, Client &client, Server &server)
 				new_op->set_channel_operator(channel_name);
 			else
 				new_op->remove_channel_operator(channel_name);
+
+			channel->broadcast(
+				Client::create_cmd_reply(client.get_mask(), "MODE", channel_name + ' ' + (add_mode ? '+' : '-') + "o " + new_op->get_nickname())
+			);
+
+			continue;
 		}
 
 		std::string flag = add_mode ? "+" : "-";
@@ -117,7 +124,6 @@ static void mode_handler(const args_t &args, Client &client, Server &server)
 			.flags = applied_flags,
 			.values = modes_values
 		};
-
 		channel->add_modes(modes);
 
 		channel->broadcast(Client::create_cmd_reply(


### PR DESCRIPTION
This pull request includes several changes to the `mode_handler` function in the `src/class/Command/mode.cpp` file. The changes primarily focus on improving the readability of the code and adding functionality to broadcast mode changes to the channel.

Improvements to readability and code structure:

* [`src/class/Command/mode.cpp`](diffhunk://#diff-97b7ead2bfdefee008e9857a6dd54477e2b103e35ac704e3a5f214256df2fc07L88-R89): Reformatted the `if (value.empty())` check to improve readability.

Enhancements to functionality:

* [`src/class/Command/mode.cpp`](diffhunk://#diff-97b7ead2bfdefee008e9857a6dd54477e2b103e35ac704e3a5f214256df2fc07R106-R111): Added a broadcast message to notify the channel of mode changes when a new operator is added or removed.
* [`src/class/Command/mode.cpp`](diffhunk://#diff-97b7ead2bfdefee008e9857a6dd54477e2b103e35ac704e3a5f214256df2fc07L120): Removed an unnecessary blank line before adding modes to the channel, ensuring a cleaner code structure.