### PR TITLE
Add support for additional HTML entities in html_decode function

### DIFF
--- a/bot/src/lib/html_decode.cpp
+++ b/bot/src/lib/html_decode.cpp
@@ -18,11 +18,14 @@ std::string html_decode(const std::string &str)
 		entities["&gt;"] = ">";
 		entities["&icirc;"] = "î";
 		entities["&iuml;"] = "ï";
+		entities["&ldquo;"] = "“";
 		entities["&lt;"] = "<";
 		entities["&ocirc;"] = "ô";
 		entities["&oelig;"] = "œ";
 		entities["&ouml;"] = "ö";
 		entities["&quot;"] = "\"";
+		entities["&rdquo;"] = "”";
+		entities["&rsquo;"] = "’";
 		entities["&ucirc;"] = "û";
 		entities["&ugrave;"] = "ù";
 		entities["&uuml;"] = "ü";


### PR DESCRIPTION
This pull request includes several updates to the `html_decode` function in `bot/src/lib/html_decode.cpp` to support additional HTML entities.

HTML entity support:

* [`bot/src/lib/html_decode.cpp`](diffhunk://#diff-cffa43e77f3e34af3b650efc29e0fe2e4036ec1297648bfb3ec5dec915bea0dfR21-R28): Added support for the HTML entities `&ldquo;`, `&rdquo;`, and `&rsquo;`.