### PR TITLE
Add bonus target to Makefile for building bot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,12 @@ $(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp Makefile
 
 -include $(DEP)
 
-.PHONY: all clean fclean re run
+.PHONY: all bonus clean fclean re run
 
 all: $(NAME)
+
+bonus:
+	@$(MAKE) -C bot
 
 clean:
 	$(RM) $(BUILD_DIR)


### PR DESCRIPTION
This pull request includes an update to the `Makefile` to add a new target for building the bonus component of the project. The most important change is the addition of the `bonus` target and its associated command to build the `bot` component.

Changes to the build process:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L55-R61): Added a new `.PHONY` target `bonus` and included the command to execute `make` in the `bot` directory.