### PR TITLE
Improve client disconnection handling by removing empty channels and deleting them

### DIFF
--- a/src/class/Server.cpp
+++ b/src/class/Server.cpp
@@ -459,9 +459,18 @@ void Server::_disconnect_client(int fd)
 	if (!stop)
 		client->broadcast_quit();
 
-	for (channels_t::iterator it = _channels.begin(); it != _channels.end(); ++it) {
-		Channel &channel = *it->second;
-		channel.remove_client(*client);
+	for (channels_t::iterator it = _channels.begin(); it != _channels.end();) {
+		Channel *channel = it->second;
+
+		channel->remove_client(*client);
+
+		if (channel->get_members().empty()) {
+			_channels.erase(it++);
+			delete channel;
+			continue;
+		}
+
+		++it;
 	}
 
 	delete client;


### PR DESCRIPTION
This pull request includes an important change to the `Server::_disconnect_client` method in the `src/class/Server.cpp` file. The change optimizes the client disconnection process by ensuring that channels with no members are deleted.

* [`src/class/Server.cpp`](diffhunk://#diff-4db7d92b4e2abe7ef080ae359bcbdf72eb873324e1e960d83a354ac0f090a793L462-R473): Modified the `Server::_disconnect_client` method to delete channels that have no members after a client is removed. This change prevents memory leaks by ensuring that empty channels are properly cleaned up.