### PR TITLE
Fix NAMES to avoid sending empty nickname replies for lost clients

### DIFF
--- a/src/class/Command/names.cpp
+++ b/src/class/Command/names.cpp
@@ -31,7 +31,8 @@ static void names_handler(const args_t &args, Client &client, Server &server)
 			}
 		}
 
-		reply += client.create_reply(RPL_NAMREPLY, "* *", lost_clients_nicknames);
+		if (!lost_clients_nicknames.empty())
+			reply += client.create_reply(RPL_NAMREPLY, "* *", lost_clients_nicknames);
 		reply += client.create_reply(RPL_ENDOFNAMES, "*", "End of NAMES list");
 	} else {
 		std::vector<std::string> channel_names = split(args[1], ',');


### PR DESCRIPTION
This pull request includes a small but significant change to the `names_handler` function in the `src/class/Command/names.cpp` file. The change ensures that a reply is only created if there are lost client nicknames.

* [`src/class/Command/names.cpp`](diffhunk://#diff-779be2e990e1b9863c08ecdf7b64f7fdf1a3ba073c9b492e3be5b9207432aec2R34): Added a condition to check if `lost_clients_nicknames` is not empty before creating a reply with `RPL_NAMREPLY`.