### PR TITLE
Server::_clean() until no disconnection

### DIFF
--- a/include/class/Server.hpp
+++ b/include/class/Server.hpp
@@ -98,9 +98,9 @@ private:
 	clients_t	_clients;
 
 // Methods
+	bool	_clean();
 	void	_accept();
 	void	_bind();
-	void	_clean();
 	void	_down();
 	void	_init_motd();
 	void	_init_socket();


### PR DESCRIPTION
This pull request includes several changes to the `Server` class in both the header and source files. The main focus of these changes is the refactoring of the `_clean` method and its integration into the server loop.

Refactoring and method integration:

* [`include/class/Server.hpp`](diffhunk://#diff-6732b5e68353cbcb7f4acb682f23ce361781e4e70a451591bf025f563447c551R101-L103): Moved the declaration of the `_clean` method from the public section to the private section.
* [`src/class/Server.cpp`](diffhunk://#diff-4db7d92b4e2abe7ef080ae359bcbdf72eb873324e1e960d83a354ac0f090a793R367-R386): Refactored the `_clean` method to improve code readability and maintainability. The method now collects file descriptors that need to be disconnected and then processes them.
* [`src/class/Server.cpp`](diffhunk://#diff-4db7d92b4e2abe7ef080ae359bcbdf72eb873324e1e960d83a354ac0f090a793L395-L412): Removed the old implementation of the `_clean` method from the `_bind` method section.
* [`src/class/Server.cpp`](diffhunk://#diff-4db7d92b4e2abe7ef080ae359bcbdf72eb873324e1e960d83a354ac0f090a793L477-R479): Updated the `_loop` method to repeatedly call `_clean` until no more disconnections are required.